### PR TITLE
Add warning for no address/no correspondence

### DIFF
--- a/app/views/sprint35b/no-permanent-address.html
+++ b/app/views/sprint35b/no-permanent-address.html
@@ -31,6 +31,15 @@ GOV.UK Prototype Kit
 
               <div class="govuk-form-group">
                 <h1 class="govuk-heading-l">Do you have an address we can send letters to?</h1>
+
+                <div class="govuk-warning-text">
+                  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                  <strong class="govuk-warning-text__text">
+                    <span class="govuk-warning-text__assistive">Warning</span>
+                    You cannot apply for a Winter Fuel Payment without a correspondence address.
+                  </strong>
+                </div>
+
                 <p class="govuk-body">This could be:</p>
                 <ul class="govuk-list govuk-list--bullet">
                   <li>a family member or trusted friend's address</li>


### PR DESCRIPTION
If no fixed abode and no correspondence address, user will be unable to proceed with the claim. This warning text makes it clear that this will happen and will allow the user to properly consider their options before answering 'no'.